### PR TITLE
Image endpoint patch.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 zukiPy.egg-info/
 dist/
 build/
+tests.py

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import zukiPy
 import asyncio
 
-api_key = ""  # Get your API key @ https://discord.gg/zukijourney
+api_key = "zu-ab6395a778f2341bac302c3efabe40e0"  # Get your API key @ https://discord.gg/zukijourney
 api_key_backup = "" # Set this to your backup API key (optional, usually for testing with different LLM APIs)
 zukiAI = zukiPy.zukiCall(api_key, api_key_backup, "gpt-3.5-turbo")
 
@@ -20,5 +20,5 @@ async def main():
 # You also need to run the async function:
 asyncio.run(main())
 
-# Hey, 1_aunchers(creator of this) here. This is made by heavily referencing Sabsterrexx. You can find him @ https://github.com/Sabsterrexx
+# Hey, 1_aunchers (creator of this) here. This is made by heavily referencing Sabsterrexx. You can find him @ https://github.com/Sabsterrexx
 # WARNING: The default backup endpoint is currently WebRaft, which is currently UNSTABLE. Change your backup 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import zukiPy
 import asyncio
 
-api_key = "zu-ab6395a778f2341bac302c3efabe40e0"  # Get your API key @ https://discord.gg/zukijourney
+api_key = ""  # Get your API key @ https://discord.gg/zukijourney
 api_key_backup = "" # Set this to your backup API key (optional, usually for testing with different LLM APIs)
 zukiAI = zukiPy.zukiCall(api_key, api_key_backup, "gpt-3.5-turbo")
 
@@ -21,4 +21,5 @@ async def main():
 asyncio.run(main())
 
 # Hey, 1_aunchers (creator of this) here. This is made by heavily referencing Sabsterrexx. You can find him @ https://github.com/Sabsterrexx
-# WARNING: The default backup endpoint is currently WebRaft, which is currently UNSTABLE. Change your backup 
+# WARNING: The default backup endpoint is currently WebRaft, which is currently UNSTABLE. Change your backup endpoint using .change_backup_endpoint() on .zuki_chat
+# and .zuki_image

--- a/zukiPy/MainMods/zukiImage.py
+++ b/zukiPy/MainMods/zukiImage.py
@@ -15,14 +15,14 @@ class zukiImage:
         self.api_endpoint_backup = endpoint
 
     async def generateImage(self, prompt, generations=1, size=250):
-        imgUrl = await self.api_caller.image_call(prompt, generations, self.api_endpoint, model="SDXL", negative_prompt="", width=1024, height=1024)
+        imgUrl = await self.api_caller.image_call(prompt, generations, self.api_endpoint, model="sdxl", negative_prompt="", width=1024, height=1024)
         if "details" in str(imgUrl):
             return ValueError(imgUrl)
         else:
             return imgUrl
 
     async def generateImageBackup(self, prompt, generations=1, size=250):
-        imgUrl = await self.api_caller_backup.image_call(prompt, generations, self.api_endpoint_backup, model="SDXL", negative_prompt="", width=1024, height=1024)
+        imgUrl = await self.api_caller_backup.image_call(prompt, generations, self.api_endpoint_backup, model="sdxl", negative_prompt="", width=1024, height=1024)
         if "details" in str(imgUrl):
             return ValueError(imgUrl)
         else:


### PR DESCRIPTION
Zukijourney recently changed the image endpoint so that you have to use "sdxl" to specify you're using the SDXL model, not "SDXL" (in upper case). As a result, this may have caused the image endpoint to become unusable when making API calls.