### PR TITLE
Bug fixes and adding getter setter method for api_backup_call.

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import asyncio
 
 api_key = ""  # Get your API key @ https://discord.gg/zukijourney
 api_key_backup = "" # Set this to your backup API key (optional, usually for testing with different LLM APIs)
+# You can set up your API backup key by calling zukiAI.change_backup_key(api_key_backup)
 zukiAI = zukiPy.zukiCall(api_key, "gpt-3.5-turbo")
 
 

--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ import asyncio
 
 api_key = ""  # Get your API key @ https://discord.gg/zukijourney
 api_key_backup = "" # Set this to your backup API key (optional, usually for testing with different LLM APIs)
-zukiAI = zukiPy.zukiCall(api_key, api_key_backup, "gpt-3.5-turbo")
+zukiAI = zukiPy.zukiCall(api_key, "gpt-3.5-turbo")
 
 
 async def main():
@@ -23,3 +23,5 @@ asyncio.run(main())
 # Hey, 1_aunchers (creator of this) here. This is made by heavily referencing Sabsterrexx. You can find him @ https://github.com/Sabsterrexx
 # WARNING: The default backup endpoint is currently WebRaft, which is currently UNSTABLE. Change your backup endpoint using .change_backup_endpoint() on .zuki_chat
 # and .zuki_image
+
+# If you want to use a certain LLM model that isn't supported, you can use zukiAI.zuki_chat.modelsList.append("model-name")

--- a/zukiPy/MainMods/zukiChat.py
+++ b/zukiPy/MainMods/zukiChat.py
@@ -12,15 +12,15 @@ class zukiChat:
         self.api_endpoint_backup = 'https://thirdparty.webraft.in/v1/chat/completions'
 
         self.systemPrompt = systemPrompt
-        modelsList = ['gpt-3.5-turbo', 'gpt-3.5-turbo-instruct', 'gpt-3.5-turbo-16k', 'gpt-4', 'gpt-4-32k', 'gpt-4-1106-preview', 'gpt-4-0125-preview', 'gpt-4-vision-preview', 'claude', 'claude-2', 'claude-2.1', 'claude-instant-v1', 'claude-instant-v1-100k', 'pplx-70b-online', 'palm-2', 'bard', 'gemini-pro', 'gemini-pro-vision', 'mixtral-8x7b', 'mixtral-8x7b-instruct', 'mistral-tiny', 'mistral-small', 'mistral-medium', 'mistral-7b-instruct', 'codellama-7b-instruct', 'llama-2-7b', 'llama-2-70b-chat', 'mythomax-l2-13b-8k', 'sheep-duck-llama', 'goliath-120b', 'nous-llama2', 'yi-34b', 'openchat', 'solar10-7b', 'pi']
+        self.modelsList = ['gpt-3.5-turbo', 'gpt-3.5-turbo-instruct', 'gpt-3.5-turbo-16k', 'gpt-4', 'gpt-4-32k', 'gpt-4-1106-preview', 'gpt-4-0125-preview', 'gpt-4-vision-preview', 'claude', 'claude-2', 'claude-2.1', 'claude-instant-v1', 'claude-instant-v1-100k', 'pplx-70b-online', 'palm-2', 'bard', 'gemini-pro', 'gemini-pro-vision', 'mixtral-8x7b', 'mixtral-8x7b-instruct', 'mistral-tiny', 'mistral-small', 'mistral-medium', 'mistral-7b-instruct', 'codellama-7b-instruct', 'llama-2-7b', 'llama-2-70b-chat', 'mythomax-l2-13b-8k', 'sheep-duck-llama', 'goliath-120b', 'nous-llama2', 'yi-34b', 'openchat', 'solar10-7b', 'pi']
 
         self.api_key_backup = api_key_backup
 
-        if (model in modelsList):
+        if (model in self.modelsList):
             self.model = model
         else:
             raise ValueError(
-                "Invalid model. Please choose from the following: " + str(modelsList))
+                "Invalid model. Please choose from the following: " + str(self.modelsList))
 
         self.temperature = temperature
 

--- a/zukiPy/SubMods/zukiChatCall.py
+++ b/zukiPy/SubMods/zukiChatCall.py
@@ -34,6 +34,6 @@ class zukiChatCall:
 
                 data=json.dumps(self.chat_data(userName, userMessage, requestedModel, systemPrompt, currTemp)))
             responseData = response.json()
-            return responseData
+            return responseData['choices'][0]['message']['content']
         except Exception as e:
             print(f"An error occurred: {e}")

--- a/zukiPy/__init__.py
+++ b/zukiPy/__init__.py
@@ -3,11 +3,15 @@ from zukiPy.MainMods.zukiImage import zukiImage
 
 
 class zukiCall:
-    def __init__(self, api_key, model="gpt-3.5-turbo",  systemPrompt="You are a helpful assistant.", temperature=0.7, api_key_backup=None):
+    def __init__(self, api_key, model="gpt-3.5-turbo",  systemPrompt="You are a helpful assistant.", temperature=0.7):
         self.api_key = api_key
-        self.api_key_backup = api_key_backup
+        self.api_key_backup = ""
         self.model = model
         self.systemPrompt = systemPrompt
         self.temperature = temperature
-        self.zuki_chat = zukiChat(api_key, api_key_backup, model, systemPrompt, temperature)
-        self.zuki_image = zukiImage(api_key, api_key_backup)
+        self.zuki_chat = zukiChat(
+            api_key, self.api_key_backup, model, systemPrompt, temperature)
+        self.zuki_image = zukiImage(api_key, self.api_key_backup)
+
+    def change_backup_key(self, key):
+        self.api_key_backup = key


### PR DESCRIPTION
This PR implements the changes discussed with @Launchers-1 yesterday. A getter and setter method has been added for the api_backup_key attribute of the __init__ class and removed from the class constructor of zukiCall since people barely use it. 

sendMessage also returns a string again instead of a JSON body, since there's no point in making a wrapper that only does half the work.